### PR TITLE
Add '-e' option to echo commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-	
+
 	STRIP ?= strip
 	# check if user is root
 	user = $(shell whoami)
 	ifeq ($(user),root)
 	INSTALL_DIR = /usr/lib/lv2
-	else 
+	else
 	INSTALL_DIR = ~/.lv2
 	endif
 
@@ -18,7 +18,7 @@
 		else ifneq ($(shell cat /proc/cpuinfo | grep ARM ) , )
 		ifneq ($(shell cat /proc/cpuinfo | grep ARMv7 ) , )
 			ifneq ($(shell cat /proc/cpuinfo | grep vfpd32 ) , )
-				SSE_CFLAGS = -march=armv7-a -mfpu=vfpv3 
+				SSE_CFLAGS = -march=armv7-a -mfpu=vfpv3
 			else ifneq ($(shell cat /proc/cpuinfo | grep vfpv3 ) , )
 				SSE_CFLAGS = -march=armv7-a -mfpu=vfpv3
 			endif
@@ -38,78 +38,79 @@
 	 -fPIC -DPIC -O2 -Wall -funroll-loops -ffast-math -fomit-frame-pointer -fstrength-reduce \
 	 -fdata-sections -Wl,--gc-sections $(SSE_CFLAGS)
 	DEBUGFLAGS += -I. -I./dsp -I./plugin -fPIC -DPIC -O2 -Wall -D DEBUG
-	LDFLAGS += -I. -shared -lm 
+	LDFLAGS += -I. -shared -lm
 	GUI_LDFLAGS += -I./gui -shared -lm `pkg-config --cflags --libs cairo` -L/usr/X11/lib -lX11
 	# invoke build files
-	OBJECTS = plugin/$(NAME).cpp 
+	OBJECTS = plugin/$(NAME).cpp
 	GUI_OBJECTS = gui/$(NAME)_x11ui.c
 	RES_OBJECTS = gui/pedal.o gui/pswitch.o
 	## output style (bash colours)
 	BLUE = "\033[1;34m"
 	RED =  "\033[1;31m"
 	NONE = "\033[0m"
+	ECHO = echo -e
 
-.PHONY : mod all clean install uninstall 
+.PHONY : mod all clean install uninstall
 
 all : check $(NAME)
 	@mkdir -p ./$(BUNDLE)
 	@cp ./plugin/*.ttl ./$(BUNDLE)
 	@mv ./*.so ./$(BUNDLE)
-	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then echo $(BLUE)"build finish, now run make install"; \
-	else echo $(RED)"sorry, build failed"; fi
-	@echo $(NONE)
+	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then $(ECHO) $(BLUE)"build finish, now run make install"; \
+	else $(ECHO) $(RED)"sorry, build failed"; fi
+	@$(ECHO) $(NONE)
 
 debug : check $(NAME)debug
 	@mkdir -p ./$(BUNDLE)
 	@cp ./plugin/*.ttl ./$(BUNDLE)
 	@mv ./*.so ./$(BUNDLE)
-	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then echo $(BLUE)"build finish, now run make install"; \
-	else echo $(RED)"sorry, build failed"; fi
-	@echo $(NONE)
+	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then $(ECHO) $(BLUE)"build finish, now run make install"; \
+	else $(ECHO) $(RED)"sorry, build failed"; fi
+	@$(ECHO) $(NONE)
 
 mod : nogui
 	@mkdir -p ./$(BUNDLE)
 	@cp -R ./MOD/* ./$(BUNDLE)
 	@mv ./*.so ./$(BUNDLE)
-	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then echo $(BLUE)"build finish, now run make install"; \
-	else echo $(RED)"sorry, build failed"; fi
-	@echo $(NONE)
+	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then $(ECHO) $(BLUE)"build finish, now run make install"; \
+	else $(ECHO) $(RED)"sorry, build failed"; fi
+	@$(ECHO) $(NONE)
 
 check :
 ifdef ARMCPU
-	@echo $(RED)ARM CPU DEDECTED, please check the optimization flags
-	@echo $(NONE)
+	@$(ECHO) $(RED)ARM CPU DEDECTED, please check the optimization flags
+	@$(ECHO) $(NONE)
 endif
 
    #@build resource object files
-$(RES_OBJECTS) : gui/pedal.png gui/pswitch.png 
-	@echo $(LGREEN)"generate resource files,"$(NONE)
+$(RES_OBJECTS) : gui/pedal.png gui/pswitch.png
+	@$(ECHO) $(LGREEN)"generate resource files,"$(NONE)
 	-@cd ./gui && ld -r -b binary pedal.png -o pedal.o
 	-@cd ./gui && ld -r -b binary pswitch.png -o pswitch.o
 
 clean :
 	@rm -f $(NAME).so
 	@rm -rf ./$(BUNDLE)
-	@echo ". ." $(BLUE)", clean up"$(NONE)
+	@$(ECHO) ". ." $(BLUE)", clean up"$(NONE)
 
 dist-clean :
 	@rm -f $(NAME).so
 	@rm -rf ./$(BUNDLE)
 	@rm -rf ./$(RES_OBJECTS)
-	@echo ". ." $(BLUE)", clean up"$(NONE)
+	@$(ECHO) ". ." $(BLUE)", clean up"$(NONE)
 
 install :
 ifneq ("$(wildcard ./$(BUNDLE))","")
 	@mkdir -p $(DESTDIR)$(INSTALL_DIR)/$(BUNDLE)
 	cp -r ./$(BUNDLE)/* $(DESTDIR)$(INSTALL_DIR)/$(BUNDLE)
-	@echo ". ." $(BLUE)", done"$(NONE)
+	@$(ECHO) ". ." $(BLUE)", done"$(NONE)
 else
-	@echo ". ." $(BLUE)", you must build first"$(NONE)
+	@$(ECHO) ". ." $(BLUE)", you must build first"$(NONE)
 endif
 
 uninstall :
 	@rm -rf $(INSTALL_DIR)/$(BUNDLE)
-	@echo ". ." $(BLUE)", done"$(NONE)
+	@$(ECHO) ". ." $(BLUE)", done"$(NONE)
 
 $(NAME) : clean $(RES_OBJECTS)
 	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,8 @@ dist-clean :
 install :
 ifneq ("$(wildcard ./$(BUNDLE))","")
 	@mkdir -p $(DESTDIR)$(INSTALL_DIR)/$(BUNDLE)
-	cp -r ./$(BUNDLE)/* $(DESTDIR)$(INSTALL_DIR)/$(BUNDLE)
-	@$(ECHO) ". ." $(BLUE)", done"$(NONE)
+	@cp -r ./$(BUNDLE)/* $(DESTDIR)$(INSTALL_DIR)/$(BUNDLE)
+	@$(ECHO) ". ." $(BLUE)"successfully installed to $(INSTALL_DIR)/$(BUNDLE)"$(NONE)
 else
 	@$(ECHO) ". ." $(BLUE)", you must build first"$(NONE)
 endif


### PR DESCRIPTION
Escape sequences for colored echo messages only work when option `-e` is passed to echo (either Bash builtin or GNU echo).

There's a second commit in the PR to suppress echoing of the `cp` operation in the `install` target, like it is handled in the other targets using `cp`. Feel free to leave this out or I'll remove the commit, if this was intentional.